### PR TITLE
chore: Add mainnet deployment info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-deployments
 dist
 generated-src
 honeypot

--- a/deployments/.gitignore
+++ b/deployments/.gitignore
@@ -1,0 +1,4 @@
+*
+!.gitignore
+!mainnet
+!mainnet/*

--- a/deployments/mainnet/honeypot.json
+++ b/deployments/mainnet/honeypot.json
@@ -1,0 +1,4 @@
+{
+    "address": "0x0974CC873dF893B302f6be7ecf4F9D4b1A15C366",
+    "blockHash": "0x3d057b9e114dafc4e36e800178bfb1fb0b8552b906ffbf4d0b82c590d702c7ea"
+}

--- a/deployments/mainnet/rollups.json
+++ b/deployments/mainnet/rollups.json
@@ -1,0 +1,13 @@
+{
+    "contracts": {
+        "History": {
+            "address": "0x385485FcaCD8AdB70C8A5a6B07155C907e78FAd9"
+        },
+        "Authority": {
+            "address": "0x9DB17B9426E6d3d517a969994E7ADDadbCa9C45f"
+        },
+        "InputBox": {
+            "address": "0x59b22D57D4f067708AB0c00552767405926dc768"
+        }
+    }
+}


### PR DESCRIPTION
Deployment info not only documents the current mainnet address, but also provides info to make it easier for people to test things out by forking mainnet.