### PR TITLE
feat: add arm64 container build

### DIFF
--- a/.github/workflows/dapp-build.yml
+++ b/.github/workflows/dapp-build.yml
@@ -75,6 +75,7 @@ jobs:
                   files: |
                       docker-bake.hcl
                       ${{ steps.meta.outputs.bake-file }}
+                      docker-bake.platforms.hcl
                   set: |
                       *.cache-from=type=gha
                       *.cache-to=type=gha,mode=max

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,3 +1,4 @@
+target "docker-platforms" {}
 
 variable "TAG" {
   default = "devel"
@@ -36,6 +37,7 @@ target "server" {
     fs = "target:fs"
   }
   tags = ["${DOCKER_ORGANIZATION}/honeypot:${TAG}-server"]
+  inherits = ["docker-platforms"]
 }
 
 target "console" {

--- a/docker-bake.platforms.hcl
+++ b/docker-bake.platforms.hcl
@@ -1,0 +1,6 @@
+target "docker-platforms" {
+    platforms = [
+        "linux/amd64",
+        "linux/arm64"
+    ]
+}


### PR DESCRIPTION
This PR will build an arm64 container image, so it will possible to use cheaper AWS ec2 instances like t4g to run rollups-node.