### PR TITLE
feat: add deployment instructions with docker compose

### DIFF
--- a/contrib/compose/Dockerfile
+++ b/contrib/compose/Dockerfile
@@ -1,0 +1,77 @@
+# cartesi-rollups-prt-node build arguments
+ARG CARTESI_ROLLUPS_PRT_NODE_VERSION=1.0.0
+ARG CARTESI_ROLLUPS_PRT_NODE_CHECKSUM_AMD64=5c9a30c862cf87b0f206287b9537b7297a9a4e07b1557bc7249ffbaf54e65aa7
+ARG CARTESI_ROLLUPS_PRT_NODE_CHECKSUM_ARM64=9c8b1cfbb2df1fa1e542833b65ca8b63a6ecc391948f9b2a260e0661c08e7f56
+
+###
+# base image stage
+FROM debian:bookworm-20250520@sha256:bd73076dc2cd9c88f48b5b358328f24f2a4289811bd73787c031e20db9f97123 AS base
+
+ARG DEBIAN_FRONTEND=noninteractive
+SHELL ["/bin/bash", "-eu", "-c"]
+
+RUN <<EOF
+apt-get update
+apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    xxd
+EOF
+
+###
+# cartesi-rollups-prt-node stage
+FROM base AS cartesi-rollups-prt-node
+ARG CARTESI_ROLLUPS_PRT_NODE_VERSION
+ARG CARTESI_ROLLUPS_PRT_NODE_CHECKSUM_AMD64
+ARG CARTESI_ROLLUPS_PRT_NODE_CHECKSUM_ARM64
+ARG TARGETARCH
+
+RUN <<EOF
+case "${TARGETARCH}" in
+    amd64) curl -fsSL https://github.com/cartesi/dave/releases/download/v${CARTESI_ROLLUPS_PRT_NODE_VERSION}/cartesi-rollups-prt-node-Linux-gnu-x86_64.tar.gz \
+            -o /tmp/cartesi-rollups-prt-node.tar.gz; \
+        echo "${CARTESI_ROLLUPS_PRT_NODE_CHECKSUM_AMD64}  /tmp/cartesi-rollups-prt-node.tar.gz" | sha256sum -c ;;
+    arm64) curl -fsSL https://github.com/cartesi/dave/releases/download/v${CARTESI_ROLLUPS_PRT_NODE_VERSION}/cartesi-rollups-prt-node-Linux-gnu-${TARGETARCH}.tar.gz \
+            -o /tmp/cartesi-rollups-prt-node.tar.gz; \
+        echo "${CARTESI_ROLLUPS_PRT_NODE_CHECKSUM_ARM64}  /tmp/cartesi-rollups-prt-node.tar.gz" | sha256sum -c ;;
+    *) echo "unsupported architecture: ${TARGETARCH}"; exit 1 ;;
+esac
+
+tar -xzf /tmp/cartesi-rollups-prt-node.tar.gz -C /usr/local/bin
+rm /tmp/cartesi-rollups-prt-node.tar.gz
+EOF
+
+###
+## honeypotv2-machine-snapshot stage
+FROM base AS honeypotv2-machine-snapshot
+ARG HONEYPOT_SNAPSHOT
+ARG HONEYPOT_VERSION
+ARG HONEYPOT_CHAIN_NAME
+ARG HONEYPOT_CHECKSUM
+
+WORKDIR /var/lib/cartesi-rollups-prt-node/snapshots/${HONEYPOT_SNAPSHOT}
+RUN <<EOF
+curl -fsSL https://github.com/cartesi/honeypot/releases/download/v${HONEYPOT_VERSION}/honeypot-snapshot-${HONEYPOT_CHAIN_NAME}.tar.gz \
+    -o /tmp/honeypot-snapshot.tar.gz
+echo "${HONEYPOT_CHECKSUM} /tmp/honeypot-snapshot.tar.gz" | sha256sum -c
+tar -xzf /tmp/honeypot-snapshot.tar.gz -C /var/lib/cartesi-rollups-prt-node/snapshots/${HONEYPOT_SNAPSHOT}
+test "${HONEYPOT_SNAPSHOT}" = "0x$(xxd -p -c32 /var/lib/cartesi-rollups-prt-node/snapshots/${HONEYPOT_SNAPSHOT}/hash)"
+EOF
+
+###
+# final stage
+FROM base
+ARG HONEYPOT_SNAPSHOT
+
+COPY --from=cartesi-rollups-prt-node        \
+    /usr/local/bin/cartesi-rollups-prt-node \
+    /usr/local/bin/cartesi-rollups-prt-node
+
+COPY --from=honeypotv2-machine-snapshot                                 \
+    /var/lib/cartesi-rollups-prt-node/snapshots/${HONEYPOT_SNAPSHOT}    \
+    /var/lib/cartesi-rollups-prt-node/snapshots/${HONEYPOT_SNAPSHOT}
+
+USER root
+WORKDIR /var/lib/cartesi-rollups-prt-node
+VOLUME [ "/var/lib/cartesi-rollups-prt-node/state" ]
+CMD ["cartesi-rollups-prt-node", "pk"]

--- a/contrib/compose/README.md
+++ b/contrib/compose/README.md
@@ -1,0 +1,58 @@
+This is a `docker compose` project that creates a container image with `cartesi-rollups-prt-node` binary and `honeypotv2` snapshot.
+
+## TL;DR
+
+
+Define these variables with proper values:
+
+
+```shell
+export WEB3_PRIVATE_KEY=
+export WEB3_RPC_URL=
+```
+
+Then, pick which chain you want to build the node for (`sepolia` or `mainnet`):
+
+
+```shell
+docker compose -f mainnet.yaml up --build
+```
+
+## Detailed version
+
+The `Dockerfile` has some build arguments that defines some versions:
+
+
+```Dockerfile
+ARG CARTESI_ROLLUPS_PRT_NODE_VERSION=1.0.0
+ARG CARTESI_ROLLUPS_PRT_NODE_CHECKSUM_AMD64=5c9a30c862cf87b0f206287b9537b7297a9a4e07b1557bc7249ffbaf54e65aa7
+ARG CARTESI_ROLLUPS_PRT_NODE_CHECKSUM_ARM64=9c8b1cfbb2df1fa1e542833b65ca8b63a6ecc391948f9b2a260e0661c08e7f56
+```
+
+There are 2 compose files, `sepolia.yaml` and `mainnet.yaml`, that should be used to honeypot dapp and prt-node deployment for the corresponding chain.
+
+
+In case you want to deploy a prt-node validating honeypotv2 at sepolia.
+
+```shell
+export WEB3_PRIVATE_KEY=<your wallet private key>
+export WEB3_RPC_URL=<your blockchain provider url>
+docker compose -f sepolia.yaml up --build
+```
+
+This will build a container with cartesi-rollups-prt-node and honeypotv2 snapshot and run it right away.
+
+### CPU and Memory
+
+The YAML file defines constrained CPU and Memory, to align with what we're using currently for honeypotv2, but you can change at will.
+
+
+```yaml
+services:
+  prt-node:
+    deploy:
+      resources:
+        limits:
+          cpus: '4.0'
+          memory: 2GiB
+```

--- a/contrib/compose/mainnet.yaml
+++ b/contrib/compose/mainnet.yaml
@@ -1,0 +1,33 @@
+name: honeypotv2-mainnet
+services:
+  prt-node:
+    init: true
+    build:
+      context: .
+      dockerfile: Dockerfile
+      tags:
+        - honeypotv2:mainnet
+      args:
+        HONEYPOT_SNAPSHOT: 0x615acc9fb8ae058d0e45c0d12fa10e1a6c9e645222c6fd94dfeda194ee427c14
+        HONEYPOT_VERSION: 2.0.0
+        HONEYPOT_CHAIN_NAME: mainnet
+        HONEYPOT_CHECKSUM: 3ac94517756af3e57b3130ed71b2399fe5f23db4450693ae8321d32890aa95b9
+    volumes:
+      - state:/var/lib/cartesi-rollups-prt-node/state
+    deploy:
+      resources:
+        limits:
+          cpus: '4.0'
+          memory: 2GiB
+    environment:
+      WEB3_CHAIN_ID: 1
+      APP_ADDRESS: 0x4c1e74ef88a75c24e49eddd9f70d82a94d19251c
+      MACHINE_PATH: /var/lib/cartesi-rollups-prt-node/snapshots/0x615acc9fb8ae058d0e45c0d12fa10e1a6c9e645222c6fd94dfeda194ee427c14
+      RUST_LOG: info
+      STATE_DIR: /var/lib/cartesi-rollups-prt-node/state
+      WEB3_PRIVATE_KEY: ${WEB3_PRIVATE_KEY}
+      WEB3_RPC_URL: ${WEB3_RPC_URL}
+
+volumes:
+  state:
+    driver: local

--- a/contrib/compose/sepolia.yaml
+++ b/contrib/compose/sepolia.yaml
@@ -1,0 +1,33 @@
+name: honeypotv2-sepolia
+services:
+  prt-node:
+    init: true
+    build:
+      context: .
+      dockerfile: Dockerfile
+      tags:
+        - honeypotv2:sepolia
+      args:
+        HONEYPOT_SNAPSHOT: 0xdbe72e1624cfed0e83469f1f5104709ecfc0d4ff6edaa7745d5912b2e184b278
+        HONEYPOT_VERSION: 2.0.0
+        HONEYPOT_CHAIN_NAME: sepolia
+        HONEYPOT_CHECKSUM: c0331c9689f663ae9a0f6ded113fd51d993b2d1131db8dc9cccb22945f0a6d53
+    volumes:
+      - state:/var/lib/cartesi-rollups-prt-node/state
+    deploy:
+      resources:
+        limits:
+          cpus: '4.0'
+          memory: 2GiB
+    environment:
+      WEB3_CHAIN_ID: 11155111
+      APP_ADDRESS: 0xccEbaA7E541BcaA99dE39ca248f0aa6CD33f9e3E
+      MACHINE_PATH: /var/lib/cartesi-rollups-prt-node/snapshots/0xdbe72e1624cfed0e83469f1f5104709ecfc0d4ff6edaa7745d5912b2e184b278
+      RUST_LOG: info
+      STATE_DIR: /var/lib/cartesi-rollups-prt-node/state
+      WEB3_PRIVATE_KEY: ${WEB3_PRIVATE_KEY}
+      WEB3_RPC_URL: ${WEB3_RPC_URL}
+
+volumes:
+  state:
+    driver: local


### PR DESCRIPTION
This pull request introduces a Docker Compose setup for deploying the `cartesi-rollups-prt-node` binary alongside the `honeypotv2` snapshot. It includes a multi-stage Dockerfile, environment configurations, and chain-specific Compose files for `mainnet` and `sepolia`. The changes are aimed at simplifying deployment and providing flexibility for resource constraints and state management.

### Dockerfile and Build Process Enhancements:
* Added a multi-stage `Dockerfile` to build and package the `cartesi-rollups-prt-node` binary and `honeypotv2` snapshot. It includes architecture-specific checksum validation and snapshot handling. (`contrib/compose/Dockerfile`, [contrib/compose/DockerfileR1-R75](diffhunk://#diff-540307a1b50b0a62eea2ecccc7c4d1fe9125887ecde619d91a7b3b5ad591d33eR1-R75))

### Docker Compose Configuration:
* Introduced a `compose.yaml` file with generic configurations, including CPU and memory constraints, environment variables, and volume setup for state persistence. (`contrib/compose/compose.yaml`, [contrib/compose/compose.yamlR1-R32](diffhunk://#diff-076c57819a65a04b86dbfc87a9dbb5223c21e3b361635824f4dc9b7949115a9dR1-R32))
* Added chain-specific Compose files (`mainnet.yaml` and `sepolia.yaml`) to define environment variables and build arguments for deploying the node on different chains. (`contrib/compose/mainnet.yaml`, [[1]](diffhunk://#diff-591528438b93f69fdbfd9b6c02267899a044d9acff75e20b701574248190bfd4R1-R16); `contrib/compose/sepolia.yaml`, [[2]](diffhunk://#diff-9469d375ff4b7f0e20f341790f3afae378cb6631fd10f2d13123302503e1f937R1-R16)

### Documentation Updates:
* Updated `README.md` to provide instructions for building and running the Docker Compose setup, including environment variable definitions, chain selection, and resource customization. (`contrib/compose/README.md`, [contrib/compose/README.mdR1-R77](diffhunk://#diff-200e0412382eaf0ab7255cb50b4a4588ffeffc2db539071bc3dd9692ef5b24faR1-R77))