### PR TITLE
Update contrib/ docs to `honeypot:v3` and `prt-node:v2`

### DIFF
--- a/contrib/compose/Dockerfile
+++ b/contrib/compose/Dockerfile
@@ -1,22 +1,20 @@
-# cartesi-rollups-prt-node build arguments
-ARG CARTESI_ROLLUPS_PRT_NODE_VERSION=1.0.0
-ARG CARTESI_ROLLUPS_PRT_NODE_CHECKSUM_AMD64=5c9a30c862cf87b0f206287b9537b7297a9a4e07b1557bc7249ffbaf54e65aa7
-ARG CARTESI_ROLLUPS_PRT_NODE_CHECKSUM_ARM64=9c8b1cfbb2df1fa1e542833b65ca8b63a6ecc391948f9b2a260e0661c08e7f56
+# syntax=docker/dockerfile:1
+
+###
+# Build arguments
+ARG CARTESI_ROLLUPS_PRT_NODE_VERSION=2.0.0
+ARG CARTESI_ROLLUPS_PRT_NODE_CHECKSUM_AMD64=4ddc4a18f46894b43f9a6c7283190133ba6ccfdd856b12cbf470a793bf68a08e
+ARG CARTESI_ROLLUPS_PRT_NODE_CHECKSUM_ARM64=3801b8a33de5cbcf55d10fa67eb18379c88cdc7c0140f2c845b14d2741c095d3
+
+# baseimage args
+ARG DEBIAN_TAG=trixie-20251103-slim
+ARG DEBIAN_DIGEST=sha256:a347fd7510ee31a84387619a492ad6c8eb0af2f2682b916ff3e643eb076f925a
 
 ###
 # base image stage
-FROM debian:bookworm-20250520@sha256:bd73076dc2cd9c88f48b5b358328f24f2a4289811bd73787c031e20db9f97123 AS base
-
+FROM debian:${DEBIAN_TAG}@${DEBIAN_DIGEST} AS base
 ARG DEBIAN_FRONTEND=noninteractive
-SHELL ["/bin/bash", "-eu", "-c"]
-
-RUN <<EOF
-apt-get update
-apt-get install -y --no-install-recommends \
-    ca-certificates \
-    curl \
-    xxd
-EOF
+RUN apt-get update
 
 ###
 # cartesi-rollups-prt-node stage
@@ -26,7 +24,12 @@ ARG CARTESI_ROLLUPS_PRT_NODE_CHECKSUM_AMD64
 ARG CARTESI_ROLLUPS_PRT_NODE_CHECKSUM_ARM64
 ARG TARGETARCH
 
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get install -y --no-install-recommends curl ca-certificates tar
+
 RUN <<EOF
+set -euo pipefail
+
 case "${TARGETARCH}" in
     amd64) curl -fsSL https://github.com/cartesi/dave/releases/download/v${CARTESI_ROLLUPS_PRT_NODE_VERSION}/cartesi-rollups-prt-node-Linux-gnu-x86_64.tar.gz \
             -o /tmp/cartesi-rollups-prt-node.tar.gz; \
@@ -42,18 +45,23 @@ rm /tmp/cartesi-rollups-prt-node.tar.gz
 EOF
 
 ###
-## honeypotv2-machine-snapshot stage
-FROM base AS honeypotv2-machine-snapshot
+## honeypot-machine-snapshot stage
+FROM base AS honeypot-machine-snapshot
 ARG HONEYPOT_SNAPSHOT
 ARG HONEYPOT_VERSION
 ARG HONEYPOT_CHAIN_NAME
 ARG HONEYPOT_CHECKSUM
 
 WORKDIR /var/lib/cartesi-rollups-prt-node/snapshots/${HONEYPOT_SNAPSHOT}
+ADD --checksum=sha256:${HONEYPOT_CHECKSUM} \
+    https://github.com/cartesi/honeypot/releases/download/v${HONEYPOT_VERSION}/honeypot-snapshot-${HONEYPOT_CHAIN_NAME}.tar.gz \
+    /tmp/honeypot-snapshot.tar.gz
+
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get install -y --no-install-recommends xxd
+
 RUN <<EOF
-curl -fsSL https://github.com/cartesi/honeypot/releases/download/v${HONEYPOT_VERSION}/honeypot-snapshot-${HONEYPOT_CHAIN_NAME}.tar.gz \
-    -o /tmp/honeypot-snapshot.tar.gz
-echo "${HONEYPOT_CHECKSUM} /tmp/honeypot-snapshot.tar.gz" | sha256sum -c
+set -eu
 tar -xzf /tmp/honeypot-snapshot.tar.gz -C /var/lib/cartesi-rollups-prt-node/snapshots/${HONEYPOT_SNAPSHOT}
 test "${HONEYPOT_SNAPSHOT}" = "0x$(xxd -p -c32 /var/lib/cartesi-rollups-prt-node/snapshots/${HONEYPOT_SNAPSHOT}/hash)"
 EOF
@@ -63,11 +71,14 @@ EOF
 FROM base
 ARG HONEYPOT_SNAPSHOT
 
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get install -y --no-install-recommends ca-certificates
+
 COPY --from=cartesi-rollups-prt-node        \
     /usr/local/bin/cartesi-rollups-prt-node \
     /usr/local/bin/cartesi-rollups-prt-node
 
-COPY --from=honeypotv2-machine-snapshot                                 \
+COPY --from=honeypot-machine-snapshot                                   \
     /var/lib/cartesi-rollups-prt-node/snapshots/${HONEYPOT_SNAPSHOT}    \
     /var/lib/cartesi-rollups-prt-node/snapshots/${HONEYPOT_SNAPSHOT}
 

--- a/contrib/compose/README.md
+++ b/contrib/compose/README.md
@@ -1,10 +1,8 @@
-This is a `docker compose` project that creates a container image with `cartesi-rollups-prt-node` binary and `honeypotv2` snapshot.
+This is a `docker compose` project that creates a container image with `cartesi-rollups-prt-node` binary and `honeypotv3` snapshot.
 
 ## TL;DR
 
-
 Define these variables with proper values:
-
 
 ```shell
 export WEB3_PRIVATE_KEY=
@@ -12,7 +10,6 @@ export WEB3_RPC_URL=
 ```
 
 Then, pick which chain you want to build the node for (`sepolia` or `mainnet`):
-
 
 ```shell
 docker compose -f mainnet.yaml up --build
@@ -22,17 +19,15 @@ docker compose -f mainnet.yaml up --build
 
 The `Dockerfile` has some build arguments that defines some versions:
 
-
 ```Dockerfile
-ARG CARTESI_ROLLUPS_PRT_NODE_VERSION=1.0.0
-ARG CARTESI_ROLLUPS_PRT_NODE_CHECKSUM_AMD64=5c9a30c862cf87b0f206287b9537b7297a9a4e07b1557bc7249ffbaf54e65aa7
-ARG CARTESI_ROLLUPS_PRT_NODE_CHECKSUM_ARM64=9c8b1cfbb2df1fa1e542833b65ca8b63a6ecc391948f9b2a260e0661c08e7f56
+ARG CARTESI_ROLLUPS_PRT_NODE_VERSION=2.0.0
+ARG CARTESI_ROLLUPS_PRT_NODE_CHECKSUM_AMD64=3801b8a33de5cbcf55d10fa67eb18379c88cdc7c0140f2c845b14d2741c095d3
+ARG CARTESI_ROLLUPS_PRT_NODE_CHECKSUM_ARM64=5bccca0ddbb3cffccb21d6f7a9ad2ca264391eb990af111223b2f866d63640f0
 ```
 
 There are 2 compose files, `sepolia.yaml` and `mainnet.yaml`, that should be used to honeypot dapp and prt-node deployment for the corresponding chain.
 
-
-In case you want to deploy a prt-node validating honeypotv2 at sepolia.
+In case you want to deploy a prt-node validating honeypotv3 at sepolia.
 
 ```shell
 export WEB3_PRIVATE_KEY=<your wallet private key>
@@ -40,12 +35,11 @@ export WEB3_RPC_URL=<your blockchain provider url>
 docker compose -f sepolia.yaml up --build
 ```
 
-This will build a container with cartesi-rollups-prt-node and honeypotv2 snapshot and run it right away.
+This will build a container with cartesi-rollups-prt-node and honeypotv3 snapshot and run it right away.
 
 ### CPU and Memory
 
-The YAML file defines constrained CPU and Memory, to align with what we're using currently for honeypotv2, but you can change at will.
-
+The YAML file defines constrained CPU and Memory, to align with what we're using currently for honeypotv3, but you can change at will.
 
 ```yaml
 services:

--- a/contrib/compose/mainnet.yaml
+++ b/contrib/compose/mainnet.yaml
@@ -1,4 +1,4 @@
-name: honeypotv2-mainnet
+name: honeypotv3-mainnet
 services:
   prt-node:
     init: true
@@ -6,12 +6,12 @@ services:
       context: .
       dockerfile: Dockerfile
       tags:
-        - honeypotv2:mainnet
+        - honeypot:v3-mainnet
       args:
-        HONEYPOT_SNAPSHOT: 0x615acc9fb8ae058d0e45c0d12fa10e1a6c9e645222c6fd94dfeda194ee427c14
-        HONEYPOT_VERSION: 2.0.0
+        HONEYPOT_SNAPSHOT: 0x144d45af1181b35f2b11c4b1150d6cb16934c28093707fb97c911ff16b3fe609
+        HONEYPOT_VERSION: 3.0.0
         HONEYPOT_CHAIN_NAME: mainnet
-        HONEYPOT_CHECKSUM: 3ac94517756af3e57b3130ed71b2399fe5f23db4450693ae8321d32890aa95b9
+        HONEYPOT_CHECKSUM: ad84d9b333308106e72c89c16906746c37bda69a1e83d0800b0543b47c1099d0
     volumes:
       - state:/var/lib/cartesi-rollups-prt-node/state
     deploy:
@@ -21,8 +21,8 @@ services:
           memory: 2GiB
     environment:
       WEB3_CHAIN_ID: 1
-      APP_ADDRESS: 0x4c1e74ef88a75c24e49eddd9f70d82a94d19251c
-      MACHINE_PATH: /var/lib/cartesi-rollups-prt-node/snapshots/0x615acc9fb8ae058d0e45c0d12fa10e1a6c9e645222c6fd94dfeda194ee427c14
+      APP_ADDRESS: 0xfDDF68726a28e418fA0c2a52c3134904a8c3e998
+      MACHINE_PATH: /var/lib/cartesi-rollups-prt-node/snapshots/0x144d45af1181b35f2b11c4b1150d6cb16934c28093707fb97c911ff16b3fe609
       RUST_LOG: info
       STATE_DIR: /var/lib/cartesi-rollups-prt-node/state
       WEB3_PRIVATE_KEY: ${WEB3_PRIVATE_KEY}

--- a/contrib/compose/sepolia.yaml
+++ b/contrib/compose/sepolia.yaml
@@ -1,4 +1,4 @@
-name: honeypotv2-sepolia
+name: honeypotv3-sepolia
 services:
   prt-node:
     init: true
@@ -6,12 +6,12 @@ services:
       context: .
       dockerfile: Dockerfile
       tags:
-        - honeypotv2:sepolia
+        - honeypot:v3-sepolia
       args:
-        HONEYPOT_SNAPSHOT: 0xdbe72e1624cfed0e83469f1f5104709ecfc0d4ff6edaa7745d5912b2e184b278
-        HONEYPOT_VERSION: 2.0.0
+        HONEYPOT_SNAPSHOT: 0xa0e299c59a356252c0723bd2cea8260547836aee5a1549dbcf2fc85b0d536845
+        HONEYPOT_VERSION: 3.0.0
         HONEYPOT_CHAIN_NAME: sepolia
-        HONEYPOT_CHECKSUM: c0331c9689f663ae9a0f6ded113fd51d993b2d1131db8dc9cccb22945f0a6d53
+        HONEYPOT_CHECKSUM: 00d646bb4e9bc23e086bac283020c5d9e6f6824dbf9b1edba9c8c84a1a8d9caa
     volumes:
       - state:/var/lib/cartesi-rollups-prt-node/state
     deploy:
@@ -21,8 +21,8 @@ services:
           memory: 2GiB
     environment:
       WEB3_CHAIN_ID: 11155111
-      APP_ADDRESS: 0xccEbaA7E541BcaA99dE39ca248f0aa6CD33f9e3E
-      MACHINE_PATH: /var/lib/cartesi-rollups-prt-node/snapshots/0xdbe72e1624cfed0e83469f1f5104709ecfc0d4ff6edaa7745d5912b2e184b278
+      APP_ADDRESS: 0xb72d7AfbE7afd35C82D1d0B3D9C714944ff5B7d8
+      MACHINE_PATH: /var/lib/cartesi-rollups-prt-node/snapshots/0xa0e299c59a356252c0723bd2cea8260547836aee5a1549dbcf2fc85b0d536845
       RUST_LOG: info
       STATE_DIR: /var/lib/cartesi-rollups-prt-node/state
       WEB3_PRIVATE_KEY: ${WEB3_PRIVATE_KEY}

--- a/contrib/deploy/README.md
+++ b/contrib/deploy/README.md
@@ -73,14 +73,14 @@ Next we setup the necessary environmental variables using the below command:
 - Mainnet:
   
 ```shell
-fly secrets set --config mainnet.fly.toml WEB3_RPC_URL=<SEPOLIA OR MAINNET RPC OF CHOICE>
+fly secrets set --config mainnet.fly.toml WEB3_RPC_URL=<MAINNET RPC OF CHOICE>
 fly secrets set --config mainnet.fly.toml WEB3_PRIVATE_KEY=<PRIVATE_KEY>
 ```
 
 - Sepolia:
   
 ```shell
-fly secrets set --config sepolia.fly.toml WEB3_RPC_URL=<SEPOLIA OR MAINNET RPC OF CHOICE>
+fly secrets set --config sepolia.fly.toml WEB3_RPC_URL=<SEPOLIA RPC OF CHOICE>
 fly secrets set --config sepolia.fly.toml WEB3_PRIVATE_KEY=<PRIVATE_KEY>
 ```
 

--- a/contrib/deploy/mainnet.fly.toml
+++ b/contrib/deploy/mainnet.fly.toml
@@ -1,24 +1,24 @@
 [build]
   dockerfile = "../compose/Dockerfile"
   [build.args]
-    HONEYPOT_SNAPSHOT = "0x615acc9fb8ae058d0e45c0d12fa10e1a6c9e645222c6fd94dfeda194ee427c14"
-    HONEYPOT_VERSION = "2.0.0"
+    HONEYPOT_SNAPSHOT = "0x144d45af1181b35f2b11c4b1150d6cb16934c28093707fb97c911ff16b3fe609"
+    HONEYPOT_VERSION = "3.0.0"
     HONEYPOT_CHAIN_NAME = "mainnet"
-    HONEYPOT_CHECKSUM = "3ac94517756af3e57b3130ed71b2399fe5f23db4450693ae8321d32890aa95b9"
+    HONEYPOT_CHECKSUM = "ad84d9b333308106e72c89c16906746c37bda69a1e83d0800b0543b47c1099d0"
 
 [env]
   WEB3_CHAIN_ID = "1"
-  APP_ADDRESS = "0x4c1e74ef88a75c24e49eddd9f70d82a94d19251c"
-  MACHINE_PATH = "/var/lib/cartesi-rollups-prt-node/snapshots/0x615acc9fb8ae058d0e45c0d12fa10e1a6c9e645222c6fd94dfeda194ee427c14"
+  APP_ADDRESS = "0xfDDF68726a28e418fA0c2a52c3134904a8c3e998"
+  MACHINE_PATH = "/var/lib/cartesi-rollups-prt-node/snapshots/0x144d45af1181b35f2b11c4b1150d6cb16934c28093707fb97c911ff16b3fe609"
   RUST_LOG = "debug"
   STATE_DIR = "/var/lib/cartesi-rollups-prt-node/state"
 
 [[mounts]]
-  source = "honeypotv2_mainnet"
+  source = "honeypotv3_mainnet"
   destination = "/var/lib/cartesi-rollups-prt-node/state"
   initial_size = "2gb"
 
 [[vm]]
-  size = "shared-cpu-4x"
-  memory = "2048"
-
+  memory = '2gb'
+  cpu_kind = 'shared'
+  cpus = 4

--- a/contrib/deploy/sepolia.fly.toml
+++ b/contrib/deploy/sepolia.fly.toml
@@ -1,23 +1,24 @@
 [build]
   dockerfile = "../compose/Dockerfile"
   [build.args]
-    HONEYPOT_SNAPSHOT = "0xdbe72e1624cfed0e83469f1f5104709ecfc0d4ff6edaa7745d5912b2e184b278"
-    HONEYPOT_VERSION = "2.0.0"
+    HONEYPOT_SNAPSHOT = "0xa0e299c59a356252c0723bd2cea8260547836aee5a1549dbcf2fc85b0d536845"
+    HONEYPOT_VERSION = "3.0.0"
     HONEYPOT_CHAIN_NAME = "sepolia"
-    HONEYPOT_CHECKSUM = "c0331c9689f663ae9a0f6ded113fd51d993b2d1131db8dc9cccb22945f0a6d53"
+    HONEYPOT_CHECKSUM = "00d646bb4e9bc23e086bac283020c5d9e6f6824dbf9b1edba9c8c84a1a8d9caa"
 
 [env]
   WEB3_CHAIN_ID = "11155111"
-  APP_ADDRESS = "0xccEbaA7E541BcaA99dE39ca248f0aa6CD33f9e3E"
-  MACHINE_PATH = "/var/lib/cartesi-rollups-prt-node/snapshots/0xdbe72e1624cfed0e83469f1f5104709ecfc0d4ff6edaa7745d5912b2e184b278"
-  RUST_LOG = "info"
+  APP_ADDRESS = "0xb72d7AfbE7afd35C82D1d0B3D9C714944ff5B7d8"
+  MACHINE_PATH = "/var/lib/cartesi-rollups-prt-node/snapshots/0xa0e299c59a356252c0723bd2cea8260547836aee5a1549dbcf2fc85b0d536845"
+  RUST_LOG = "debug"
   STATE_DIR = "/var/lib/cartesi-rollups-prt-node/state"
 
 [[mounts]]
-  source = "honeypotv2_sepolia"
+  source = "honeypotv3_sepolia"
   destination = "/var/lib/cartesi-rollups-prt-node/state"
   initial_size = "2gb"
 
 [[vm]]
-  size = "shared-cpu-4x"
-  memory = "2048"
+  memory = '2gb'
+  cpu_kind = 'shared'
+  cpus = 4


### PR DESCRIPTION
This pull request updates the Docker Compose setup and deployment configuration to use honeypotv3 snapshots and Cartesi Rollups PRT Node version 2.0.0 for both mainnet and sepolia environments. It replaces all references to honeypotv2 with honeypotv3, updates relevant checksums, addresses, and environment variables, and modernizes the Dockerfile and deployment files for improved consistency and maintainability.

**Upgrade to honeypotv3 and Cartesi Rollups PRT Node 2.0.0:**

* Updated Dockerfile to use `CARTESI_ROLLUPS_PRT_NODE_VERSION=2.0.0` and new honeypotv3 snapshot arguments, checksums, and download logic. Also refactored the build stages and package installation for clarity and maintainability. [[1]](diffhunk://#diff-540307a1b50b0a62eea2ecccc7c4d1fe9125887ecde619d91a7b3b5ad591d33eL1-R17) [[2]](diffhunk://#diff-540307a1b50b0a62eea2ecccc7c4d1fe9125887ecde619d91a7b3b5ad591d33eR27-R29) [[3]](diffhunk://#diff-540307a1b50b0a62eea2ecccc7c4d1fe9125887ecde619d91a7b3b5ad591d33eL45-R62) [[4]](diffhunk://#diff-540307a1b50b0a62eea2ecccc7c4d1fe9125887ecde619d91a7b3b5ad591d33eR72-R79)
* Changed compose files (`mainnet.yaml` and `sepolia.yaml`) to reference honeypotv3, update snapshot hashes, versions, checksums, and relevant environment variables such as `APP_ADDRESS` and `MACHINE_PATH`. [[1]](diffhunk://#diff-591528438b93f69fdbfd9b6c02267899a044d9acff75e20b701574248190bfd4L1-R14) [[2]](diffhunk://#diff-591528438b93f69fdbfd9b6c02267899a044d9acff75e20b701574248190bfd4L24-R25) [[3]](diffhunk://#diff-9469d375ff4b7f0e20f341790f3afae378cb6631fd10f2d13123302503e1f937L1-R14) [[4]](diffhunk://#diff-9469d375ff4b7f0e20f341790f3afae378cb6631fd10f2d13123302503e1f937L24-R25)

**Documentation updates:**

* Updated `README.md` in `contrib/compose` to reflect honeypotv3 usage, new build arguments, and instructions for both mainnet and sepolia deployments. [[1]](diffhunk://#diff-200e0412382eaf0ab7255cb50b4a4588ffeffc2db539071bc3dd9692ef5b24faL1-L16) [[2]](diffhunk://#diff-200e0412382eaf0ab7255cb50b4a4588ffeffc2db539071bc3dd9692ef5b24faL25-R42)
* Clarified RPC URL instructions in `contrib/deploy/README.md` for mainnet and sepolia environments.

**Deployment configuration improvements:**

* Updated Fly.io deployment files (`mainnet.fly.toml` and `sepolia.fly.toml`) to use honeypotv3 snapshot, updated environment variables, and modernized VM configuration syntax. [[1]](diffhunk://#diff-d07c064b570c8bb4d79c28f377e68d5b54cb933e4071ad9ab2483bbbeacda5e6L11-R24) [[2]](diffhunk://#diff-a98778a9a6173e54b0aa1e0f54ace302d221aeda7703bf086dbd61b8661fe6c1L4-R24)